### PR TITLE
Make sure images are found when using select2 plugin

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 8.8.dev0 - (unreleased)
 -----------------------
 * Bug fix: use applyPrefix=1 for the select2 CSS registration so images like 
-  select2.png are found correctly as it is ++resource++.
+  select2.png are found correctly.
   [gbastien]
 
 8.7 - (2016-03-01)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -3,6 +3,9 @@ Changelog
 
 8.8.dev0 - (unreleased)
 -----------------------
+* Bug fix: use applyPrefix=1 for the select2 CSS registration so images like 
+  select2.png are found correctly as it is ++resource++.
+  [gbastien]
 
 8.7 - (2016-03-01)
 ------------------

--- a/eea/jquery/profiles-bbb/select2/cssregistry.xml
+++ b/eea/jquery/profiles-bbb/select2/cssregistry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <object name="portal_css">
     <stylesheet id="++resource++select2/select2.css" authenticated="True"
-        insert-after="++resource++jquery.annotator.css" />
+        applyPrefix="1" insert-after="++resource++jquery.annotator.css" />
 </object>


### PR DESCRIPTION
Because images are accessible using ++resource++select2 in their path.

If portal_css when debug mode is off, images are not displayed in the select2 widget (autocomplete), this corrects the problem.

Thank you!

Gauthier
